### PR TITLE
Fix get_results query

### DIFF
--- a/game_db.py
+++ b/game_db.py
@@ -223,3 +223,8 @@ def get_results(session_id: str) -> List[Dict[str, str]]:
     [{"player": ..., "choice": ...}, ...]
     """
     with _get_conn() as conn:
+        rows = conn.execute(
+            "SELECT player_id, choice FROM moves WHERE session_id = ? ORDER BY rowid",
+            (session_id,)
+        ).fetchall()
+    return [{"player": pid, "choice": choice} for pid, choice in rows]


### PR DESCRIPTION
## Summary
- implement missing database query for `get_results`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de83fcd4c8332a50611e0c9f2763d