### PR TITLE
Fix DB file config in concurrency test

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -15,7 +15,8 @@ def test_concurrent_joins():
     # Use a temporary directory for isolation
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
-        game_db.DB_FILE = tmp_path / "game.db"
+        game_parameters.DB_FILE = tmp_path / "game.db"
+        game_db.DB_FILE = game_parameters.DB_FILE
         game_db.init_db()
 
         results = []


### PR DESCRIPTION
## Summary
- ensure test_concurrent_joins updates both game_db and game_parameters with the temporary DB file
- reinitialise the database after setting the path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de9315b308332b092f0bb69eb2196