### PR TITLE
Fix TypedDict import

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@
 from __future__ import annotations
 
 import os
-from typing import TypedDict
+from typing_extensions import TypedDict
 from enum import Enum
 
 from fastapi import FastAPI, HTTPException


### PR DESCRIPTION
## Summary
- use `typing_extensions.TypedDict` instead of `typing.TypedDict`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684defc770188332b9dc1e444306c536